### PR TITLE
Resolve Trips index merge conflict

### DIFF
--- a/trips/2025-01-spanish-wells-bahamas.md
+++ b/trips/2025-01-spanish-wells-bahamas.md
@@ -1,0 +1,54 @@
+---
+layout: default
+title: "Island Time in Spanish Wells: A Serene January Escape to the Bahamas"
+permalink: /trips/2025-01-spanish-wells-bahamas/
+description: "A week-long family getaway to Spanish Wells, Bahamas featuring a waterfront VRBO retreat, pink-sand beaches, boat adventures, and the laid-back rhythms of island life in January"
+---
+<h1>{{ page.title }}</h1>
+<p class="subtitle">January 2025</p>
+
+**Introduction**
+After weeks of gray New England skies, we craved warmth, turquoise water, and a slower pace. So in January 2025, we traded Boston's snow boots for sandals and hopped a flight to Eleuthera, Bahamas, with the ferry whisking us to the tiny island of Spanish Wells. For seven glorious days, we settled into a VRBO perched right on the harbor, letting the rhythm of the tides dictate our schedule. Here's a detailed look at our island escape, complete with ideas to help you plan your own winter thaw in Spanish Wells.
+
+**Arriving in Island Paradise**
+Getting to Spanish Wells feels like a mini adventure. We flew into North Eleuthera Airport, where cheerful taxi drivers wait curbside. A quick ride brought us to the Gene's Bay dock, and within minutes we were aboard the water taxi gliding across glassy waters. The ferry captain pointed out neighboring Russell Island and the narrow sandbars as we approached the pastel homes of Spanish Wells. By the time we stepped onto the dock, the cool Atlantic breeze and scent of frangipani had us fully in vacation mode.
+
+**Our Waterfront VRBO Retreat**
+The star of our trip was the VRBO home we rented right on the water. Floor-to-ceiling windows framed the harbor, and a wraparound deck gave us front-row seats to the parade of lobster boats heading out at dawn. Mornings began with coffee on the dock while the kids dangled their feet in the clear shallows searching for starfish. The house came stocked with kayaks, snorkel gear, and even a golf cart—Spanish Wells' preferred mode of transportation—so we could explore without a car. We loved ending each day grilling fresh catch on the patio as the sun melted into cotton candy hues over the sea.
+
+**Beach Days on Pink Sand**
+Spanish Wells might be petite, but it boasts some of the prettiest beaches we've ever visited. We spent lazy afternoons on Spanish Wells North Beach, a crescent of powdery pink sand and calm, shallow water perfect for kids. The sandbar stretches far into the ocean, making it ideal for long walks and impromptu shell hunts. On windier days, we crossed the bridge to Russell Island and set up camp at the secluded Russell Island Beach, where the waves are a bit livelier and the sunsets are unforgettable. Beach chairs, umbrellas, and a cooler packed with Bahamian Kalik made each day feel effortlessly luxurious.
+
+**Exploring by Boat**
+Midweek we chartered a small boat with Captain Smiley for a half-day excursion. He navigated us to nearby Meeks Patch, where the famous swimming pigs paddled right up for treats. We snorkeled over coral heads teeming with parrotfish and spotted a lazy sea turtle gliding through the reef. Captain Smiley also showed us the sand flats where local fishermen dive for lobster—a fascinating glimpse into the island's livelihood. The kids' highlight? Anchoring at a deserted sandbar and racing along the shoreline with no footprints but our own.
+
+**Island Eats and Local Flavor**
+While the VRBO kitchen made self-catering easy, we couldn't resist sampling Spanish Wells' laid-back dining scene. Wreckers Bar & Grill became our go-to for conch fritters, grilled grouper, and sunset mocktails. We grabbed flaky guava duff pastries from Budda's Snack Shack for breakfast on the deck, and one evening we took the golf cart to The Shipyard for wood-fired pizza and live music. Don't miss popping into Kathy's Bakery for fresh coconut bread—it's the perfect snack after a morning swim.
+
+**Laid-Back Island Adventures**
+Spanish Wells rewards slow exploration. We spent a day biking the quiet streets, admiring pastel cottages and stopping at the Spanish Wells Heritage Museum to learn about the island's Loyalist roots. Another morning we kayaked from our dock along the mangroves, watching stingrays dart beneath our paddles. With no crowds and gentle island hospitality, every outing felt relaxed and safe for the kids. Even grocery runs to the Ponderosa Shell & Gift Shop turned into mini adventures as we chatted with the friendly owners about island life.
+
+**Travel Tips for Spanish Wells**
+- **Plan the Journey**: Coordinate flights with the North Eleuthera water taxi schedule to minimize wait times, and carry cash for the quick boat ride.
+- **Pack Light but Smart**: Bring reef-safe sunscreen, rash guards, and plenty of bug spray for calm evenings by the water.
+- **Reserve Rentals Early**: Golf carts and boat charters book up fast in peak season. Secure yours before arrival for maximum flexibility.
+- **Support Local**: Stock up at the island grocery stores and bakeries, and chat with fishermen at the dock for the freshest lobster and snapper.
+
+**Conclusion**
+Spanish Wells proved to be the winter retreat we didn't know we needed—a place where mornings begin with sunrises over the harbor and evenings end with the lullaby of gentle waves. The combination of a waterfront home base, welcoming locals, and endless turquoise water made our January escape truly restorative. If you're dreaming of a warm-weather getaway that's equal parts relaxing and adventurous, this tiny Bahamian gem should be at the top of your list. Happy island travels!
+
+**Places Mentioned**
+- North Eleuthera Airport
+- Gene's Bay Dock
+- Spanish Wells North Beach
+- Russell Island
+- Russell Island Beach
+- Meeks Patch
+- Wreckers Bar & Grill
+- Budda's Snack Shack
+- The Shipyard Restaurant
+- Kathy's Bakery
+- Spanish Wells Heritage Museum
+- Ponderosa Shell & Gift Shop
+
+{% include sponsor.html %}

--- a/trips/2025-03-times-square-new-york-city.md
+++ b/trips/2025-03-times-square-new-york-city.md
@@ -1,0 +1,56 @@
+---
+layout: default
+title: "Neon Nights in Times Square: A March 2025 Escape to New York City"
+permalink: /trips/2025-03-times-square-new-york-city/
+description: "A three-day family getaway to Times Square, New York City with a stay at the Marriott Marquis, dazzling skyline views, Broadway's The Great Gatsby, and midtown adventures in March 2025"
+---
+<h1>{{ page.title }}</h1>
+<p class="subtitle">March 2025</p>
+
+**Introduction**
+After a long New England winter, our family was craving big-city energy, bright lights, and an itinerary packed with iconic experiences. So in March 2025, we traded Boston's snow piles for Times Square's towering billboards and spent three exhilarating days in the heart of New York City. Staying steps from the action at the Marriott Marquis gave us a front-row seat to the electric pulse of Midtown. Here's how we squeezed Broadway magic, sky-high views, and memorable meals into a long weekend in the city that never sleeps.
+
+**Arriving in the Heart of Times Square**
+We took the early morning Amtrak from Boston's South Station, arriving at Moynihan Train Hall by late morning. From there, a quick taxi ride delivered us straight onto Seventh Avenue, where Times Square greeted us with its kaleidoscope of screens and street performers. The kids were mesmerized by the sheer scale of the plaza, and even after multiple visits, I couldn't help but feel giddy standing beneath the neon glow. We immediately ducked into the Times Square Visitor Center to pick up discount coupons and maps—handy for planning our whirlwind stay.
+
+**Our Sky-High Base at the Marriott Marquis**
+The Marriott Marquis rises right above the action, and checking in felt like entering our own sleek retreat above the bustle. Our high-floor room overlooked the TKTS steps and the digital canyon below, turning the windows into a living movie screen day and night. The hotel’s famous glass elevators gave us vertigo-inducing glimpses of the atrium every time we zipped up and down. We made the most of the Broadway Lounge for quick breakfasts with panoramic views, and one evening we rode up to the newly refreshed View Restaurant & Lounge to watch the city lights twinkle while we sipped mocktails.
+
+**Broadway Dreams: The Great Gatsby**
+The highlight of the trip was our night at the Broadway Theatre to see "The Great Gatsby." We booked matinee tickets to avoid keeping the kids out too late, and the Art Deco set design instantly transported us into the Roaring Twenties. The cast's powerhouse vocals, dazzling costumes, and immersive choreography kept us on the edge of our seats. Walking back to the hotel beneath the marquee lights, we couldn’t stop humming the show's finale and chatting about our favorite scenes. Pro tip: stop by the Marquis' concierge desk for last-minute ticket tips—they helped us snag great seats at face value.
+
+**Iconic Midtown Moments**
+With only three days, we focused on Midtown landmarks within walking distance. Early one morning we strolled to Rockefeller Center for tickets to Top of the Rock, timing our ascent for golden hour. The 360-degree views of the Empire State Building, Central Park, and the Hudson River were worth every chilly gust. We also explored the New York Public Library's majestic reading rooms, letting the kids complete the library's scavenger hunt before wandering through Bryant Park's winter village stalls for hot chocolate and warm pretzels.
+
+**Interactive Fun for All Ages**
+Times Square is a playground for pop culture lovers. We ducked into the new Museum of Broadway to trace the history of musical theater with hands-on exhibits, costume displays, and a replica backstage area that thrilled the kids. Nearby, the RiseNY experience whisked us through a short film about NYC's rise before strapping us into a soaring ride over city landmarks—a hit for thrill seekers. We balanced the high-octane attractions with a calmer afternoon at St. Patrick's Cathedral, lighting candles and admiring the stained glass.
+
+**Tastes of the City**
+Eating in Times Square can be a minefield of tourist traps, but we found plenty of delicious bites. For quick lunches, we relied on Urbanspace Vanderbilt’s food hall a short walk away, where everyone chose their own gourmet adventure. Dinner one night was at Carmine's, where family-style platters of chicken parmigiana and garlic bread disappeared in minutes. We grabbed bagels from Liberty Bagels for breakfast on the go, and no trip was complete without a stop at Junior’s for creamy New York cheesecake enjoyed back in our room while watching the bustle below.
+
+**Travel Tips for Times Square**
+- **Book Central Accommodations**: Staying at the Marriott Marquis kept us in the center of the action and made midday breaks with the kids easy.
+- **Plan Attraction Timing**: Visit Top of the Rock early to beat the crowds, and schedule popular museums or immersive experiences with timed-entry tickets.
+- **Leverage Public Transit**: A 7-day MetroCard covered our subway rides to nearby neighborhoods like Chelsea and the Upper West Side when we needed a change of scenery.
+- **Fuel Up Smart**: Seek out nearby food halls and local favorites for meals—reservations for pre-theater dinners go fast.
+
+**Conclusion**
+Our March escape to Times Square delivered everything we hoped for: Broadway brilliance, skyline views, and the contagious energy of New York City. Staying at the Marriott Marquis gave us a comfortable home base amid the excitement, while thoughtful planning ensured we packed each day with memorable experiences without feeling rushed. Whether you're a first-time visitor or a seasoned NYC traveler, a few days in Times Square is the perfect antidote to late-winter blues. See you under the neon lights!
+
+**Places Mentioned**
+- Times Square Visitor Center
+- Marriott Marquis Times Square
+- Broadway Theatre
+- Top of the Rock Observation Deck
+- Rockefeller Center
+- New York Public Library
+- Bryant Park
+- Museum of Broadway
+- RiseNY
+- St. Patrick's Cathedral
+- Urbanspace Vanderbilt
+- Carmine's Italian Restaurant
+- Liberty Bagels Midtown
+- Junior's Restaurant & Bakery
+
+{% include sponsor.html %}

--- a/trips/index.md
+++ b/trips/index.md
@@ -12,6 +12,11 @@ rss_url: /trips/rss.xml
 
 Below are the trips taken during the most recent years. Enjoy!
 
+<h2 id="2025">2025</h2>
+
+* [Island Time in Spanish Wells: A Serene January Escape to the Bahamas](/trips/2025-01-spanish-wells-bahamas/) "A week-long family getaway to Spanish Wells, Bahamas featuring a waterfront VRBO retreat, pink-sand beaches, boat adventures, and the laid-back rhythms of island life in January". (January 2025)
+* [Neon Nights in Times Square: A March 2025 Escape to New York City](/trips/2025-03-times-square-new-york-city/) "A three-day Times Square getaway featuring a stay at the Marriott Marquis, Broadway's The Great Gatsby, skyline views, and family-friendly Midtown fun". (March 2025)
+
 <h2 id="2024">2024</h2>
 
 * [A Winter Weekend at the Cliff House: Embracing Ogunquit, Maine in February](/trips/2024-02-cliff-house-ogunquit-maine/) "A peaceful winter getaway to the Cliff House in Ogunquit, Maine featuring luxury spa amenities, dramatic ocean views, and the serene beauty of coastal Maine in February". (February 2024)


### PR DESCRIPTION
## Summary
- reorder the 2025 Trips index entries so the January Spanish Wells getaway appears before the March Times Square trip, matching the chronological structure used for other years and keeping both posts visible after conflict resolution

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1a3bdcefc832dbc66209a9383671f