### PR TITLE
Replace hero image with sailing theme

### DIFF
--- a/images/sailing-theme.svg
+++ b/images/sailing-theme.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 560" width="560" height="560" role="img" aria-labelledby="title desc">
+  <title id="title">Sailboat on a golden horizon</title>
+  <desc id="desc">A stylized sailboat glides across calm water toward the sunset, evoking the spirit of sailing adventures.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f6d365" />
+      <stop offset="50%" stop-color="#fda085" />
+      <stop offset="100%" stop-color="#f6f1d3" />
+    </linearGradient>
+    <linearGradient id="water" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#19547b" />
+      <stop offset="100%" stop-color="#4facfe" />
+    </linearGradient>
+    <linearGradient id="sail" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" />
+      <stop offset="100%" stop-color="#d1e8ff" />
+    </linearGradient>
+  </defs>
+  <rect width="560" height="360" fill="url(#sky)" />
+  <rect y="360" width="560" height="200" fill="url(#water)" />
+  <circle cx="420" cy="140" r="60" fill="#ffe59d" opacity="0.9" />
+  <g transform="translate(160,220)">
+    <rect x="110" y="150" width="8" height="120" fill="#5f4632" />
+    <path d="M114 40 L114 270 L-20 270 Q70 220 114 150" fill="#1e3d59" opacity="0.65" />
+    <path d="M114 40 L260 200 L114 200 Z" fill="url(#sail)" />
+    <path d="M114 80 L10 220 L114 220 Z" fill="#f4f6f9" opacity="0.85" />
+    <path d="M-40 270 L270 270 Q230 310 0 320 Q-130 300 -40 270" fill="#2b3a42" opacity="0.85" />
+  </g>
+  <g opacity="0.6" fill="#ffffff">
+    <circle cx="120" cy="120" r="18" />
+    <circle cx="140" cy="140" r="12" />
+    <circle cx="100" cy="150" r="10" />
+    <circle cx="210" cy="90" r="14" />
+    <circle cx="230" cy="110" r="10" />
+  </g>
+  <g opacity="0.2" fill="#ffffff">
+    <ellipse cx="200" cy="470" rx="80" ry="12" />
+    <ellipse cx="360" cy="490" rx="110" ry="16" />
+  </g>
+</svg>

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: Hyblan.com
 permalink: /
 ---
 
-<img class="right" src="/images/unicycling-glory-sepia-560.jpg" alt="Hyblan.com unicycling on his wedding day" title="Me unicycling on my wedding day" />
+<img class="right" src="/images/sailing-theme.svg" alt="Hyblan.com sailing toward a sunset" title="Charting a sailing adventure" />
 
 Welcome to Hyblan.com - Your Passport to Unforgettable Adventures!
 


### PR DESCRIPTION
## Summary
- replace the homepage hero image reference with a new sailing-themed illustration
- add an accessible SVG illustration depicting a sailboat at sunset to the images directory

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d2dbfa59d8832da09daecca279b8de