### PR TITLE
Add optional force overwrite toggle to mirror workflow

### DIFF
--- a/.github/workflows/mirror-develop.yml
+++ b/.github/workflows/mirror-develop.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   mirror:
     runs-on: ubuntu-latest
+    env:
+      FORCE_OVERWRITE: ${{ vars.MIRROR_FORCE_OVERWRITE }}
     permissions:
       contents: read
     steps:
@@ -36,6 +38,12 @@ jobs:
 
           git ls-remote --heads target || (echo "Cannot reach target repo" && exit 1)
 
-          git push target HEAD:refs/heads/develop --force-with-lease
+          push_flag="--force-with-lease"
+
+          if [ "${FORCE_OVERWRITE:-}" = "true" ]; then
+            push_flag="--force"
+          fi
+
+          git push target HEAD:refs/heads/develop "${push_flag}"
 
           echo "Mirrored hyblancode.github.io@develop -> hyblancode.github.io-develop@develop"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-Source code for my website, [hyblan.com](https://hyblan.com/)
+Source code for my website, [hyblan.com](https://hyblan.com/).
+
+## Mirroring configuration
+
+The `Mirror develop -> hyblancode/hyblancode.github.io-develop:develop` workflow mirrors the `develop` branch into the `hyblancode.github.io-develop` repository. Set the repository variable `MIRROR_FORCE_OVERWRITE` to `true` to enable unconditional mirroring, which forces the target branch even when history diverges. When the variable is unset or `false`, the workflow uses a force-with-lease push for safer mirroring.


### PR DESCRIPTION
## Summary
- allow configuring the mirror job with the MIRROR_FORCE_OVERWRITE repository variable by wiring it into the workflow environment
- switch the push step to honor the flag by selecting between --force-with-lease and --force
- document how to enable unconditional mirroring in the README

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d5bdae17b4832d99e18f98008e725c